### PR TITLE
Fixes #3 - Allow usage with non-US phone numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Migrate Authy to Twilio Verify API (for SMS and TOTP 2FA)
 
 ### This gem is meant to be a drop-in replacement for devise-authy in a Rails app (minus the following features)
-- Currently only support mobile phones with US country codes
 - Removed Onetouch support
 - Removed ability to request a phone call
 
@@ -26,7 +25,7 @@
 
   ```
 - you can also delete the `users.authy_id` column if you choose
-- Twilio Verify service sms will be sent to `users.mobile_phone`, so make sure you store the users 2fa phone number in this column, can make this field name dynamic in the future
+- Twilio Verify service sms will be sent to `users.mobile_phone`, so make sure you store the users 2fa phone number in this column in [e164 format](https://www.twilio.com/docs/glossary/what-e164), can make this field name dynamic in the future
 - Do a project code wide search & replace of these terms
   - `devise-authy` -> `devise-twilio-verify`
   - `authy_` -> `twilio_verify_`

--- a/app/services/twilio_verify_service.rb
+++ b/app/services/twilio_verify_service.rb
@@ -2,11 +2,11 @@ class TwilioVerifyService
   attr_reader :twilio_client, :twilio_account_sid, :twilio_auth_token, :twilio_verify_service_sid
 
   def self.send_sms_token(phone_number)
-    new.twilio_verify_service.verifications.create(to: e164_format(phone_number), channel: 'sms')
+    new.twilio_verify_service.verifications.create(to: phone_number, channel: 'sms')
   end
 
   def self.verify_sms_token(phone_number, token)
-    new.twilio_verify_service.verification_checks.create(to: e164_format(phone_number), code: token)
+    new.twilio_verify_service.verification_checks.create(to: phone_number, code: token)
   end
 
   def self.verify_totp_token(user, token)
@@ -38,10 +38,6 @@ class TwilioVerifyService
       .update(auth_payload: token)
   end
 
-  def self.e164_format(phone_number)
-    "+1#{phone_number.gsub(/[^0-9a-z\\s]/i, '')}"
-  end
-
   def initialize
     @twilio_account_sid = Rails.application.credentials.twilio_account_sid || ENV['TWILIO_ACCOUNT_SID']
     @twilio_auth_token = Rails.application.credentials.twilio_auth_token || ENV['TWILIO_AUTH_TOKEN']
@@ -58,9 +54,5 @@ class TwilioVerifyService
 
   def twilio_verify_service_v2
     twilio_client.verify.v2.services(twilio_verify_service_sid)
-  end
-
-  def e164_format(phone_number)
-    self.class.e164_format(phone_number)
   end
 end


### PR DESCRIPTION
- Remove e164 formatting method from TwilioVerifyService, User#mobile_phone must be stored in -e164 format.
- Note required format of mobile_phone column in README